### PR TITLE
Update Libsass support

### DIFF
--- a/_data/support.yml
+++ b/_data/support.yml
@@ -8,7 +8,7 @@ inspect_function:
     ruby_sass_3_2: false
     ruby_sass_3_3: true
     ruby_sass_3_4: true
-    libsass: false
+    libsass: true
 
 set_nth_function:
     ruby_sass_3_2: false
@@ -20,7 +20,7 @@ random_function:
     ruby_sass_3_2: false
     ruby_sass_3_3: true
     ruby_sass_3_4: true
-    libsass: false
+    libsass: true
 
 unique_id_function:
     ruby_sass_3_2: false
@@ -92,7 +92,7 @@ downward_for:
     ruby_sass_3_2: false
     ruby_sass_3_3: true
     ruby_sass_3_4: true
-    libsass: false
+    libsass: true
 
 rebeccapurple_color:
     ruby_sass_3_2: false
@@ -122,7 +122,7 @@ not_operator:
     ruby_sass_3_2: true
     ruby_sass_3_3: true
     ruby_sass_3_4: true
-    libsass: false
+    libsass: true
 
 nested_interpolations:
     ruby_sass_3_2: true


### PR DESCRIPTION
I don't know what the criteria is for documenting "libsass" support. Stable release? These seem to be fixed in the master branch:
- not operator: https://github.com/sass/libsass/commit/dc58506439edb940c2ad34248f186d29910497ca
- random function: https://github.com/sass/libsass/commit/1bacd107ccdd155b90894f178db3d6d938d98ef5
- inspect function: https://github.com/sass/libsass/commit/4f905ad597d10aade0c5ae1d0584716f44d9cb86
- downward for: https://github.com/sass/libsass/commit/98a6ff3d3f3768be3da499e47f5db1c7a813212e
